### PR TITLE
security: CWE-345: x5u trusted identity bypass — VC-53737

### DIFF
--- a/internal/signature/verifier.go
+++ b/internal/signature/verifier.go
@@ -1,8 +1,11 @@
 package signature
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
 	"errors"
+	"net/url"
 	"strings"
 
 	"github.com/notaryproject/notation-go/plugin/proto"
@@ -10,6 +13,7 @@ import (
 	"github.com/venafi/notation-venafi-csp/internal/pkix"
 	"github.com/venafi/notation-venafi-csp/internal/signature/jws"
 	"github.com/venafi/vsign/pkg/venafi/tpp"
+	"github.com/venafi/vsign/pkg/vsign"
 )
 
 const (
@@ -35,17 +39,77 @@ func Verify(ctx context.Context, req *plugin.VerifySignatureRequest) (*plugin.Ve
 	results := make(map[plugin.Capability]*plugin.VerificationResult)
 	var attr []string
 
-	if url, found := req.Signature.CriticalAttributes.ExtendedAttributes[jws.HeaderVerificationPluginX5U]; found {
+	if x5uAttr, found := req.Signature.CriticalAttributes.ExtendedAttributes[jws.HeaderVerificationPluginX5U]; found {
 		// TPP 23.1+ capability
-		leaf, err := tpp.GetPKSCertificate(url.(string))
-		// If x5u exists however TPP no longer manages the lifecycle then fail identity validation
-		if err != nil {
+		x5uURL, ok := x5uAttr.(string)
+		if !ok {
 			results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
 				Success: false,
-				//Reason:  "identity validation failed due to missing certificate in CodeSign Protect",
-				Reason: err.Error(),
+				Reason:  "x5u attribute is not a string",
 			}
 		} else {
+			// Validate x5u URL scheme and host
+			parsed, err := url.Parse(x5uURL)
+			if err != nil {
+				results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+					Success: false,
+					Reason:  "x5u URL parsing failed: " + err.Error(),
+				}
+			} else if parsed.Scheme != "https" {
+				results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+					Success: false,
+					Reason:  "x5u URL must use HTTPS scheme",
+				}
+			} else {
+				// Validate x5u host matches configured TPP host
+				var tppHost string
+				if configPath, ok := req.PluginConfig["config"]; ok {
+					cfg, err := vsign.BuildConfig(ctx, configPath)
+					if err == nil {
+						baseURL, err := url.Parse(cfg.BaseUrl)
+						if err == nil {
+							tppHost = baseURL.Host
+						}
+					}
+				}
+				if tppHost == "" {
+					results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+						Success: false,
+						Reason:  "x5u validation requires pluginConfig[config] to verify TPP host",
+					}
+				} else if parsed.Host != tppHost {
+					results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+						Success: false,
+						Reason:  "x5u URL host does not match configured TPP host",
+					}
+				} else {
+					// Fetch certificate from validated x5u URL
+					leaf, err := tpp.GetPKSCertificate(x5uURL)
+					// If x5u exists however TPP no longer manages the lifecycle then fail identity validation
+					if err != nil {
+						results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+							Success: false,
+							//Reason:  "identity validation failed due to missing certificate in CodeSign Protect",
+							Reason: err.Error(),
+						}
+					} else {
+						// Bind x5u certificate to envelope signing certificate by comparing public keys
+						if len(req.Signature.CertificateChain) == 0 {
+							results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+								Success: false,
+								Reason:  "signature certificateChain is empty",
+							}
+						} else if signerCert, perr := x509.ParseCertificate(req.Signature.CertificateChain[0]); perr != nil {
+							results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+								Success: false,
+								Reason:  "error parsing signature certificateChain leaf",
+							}
+						} else if !bytes.Equal(leaf.RawSubjectPublicKeyInfo, signerCert.RawSubjectPublicKeyInfo) {
+							results[plugin.CapabilityTrustedIdentityVerifier] = &plugin.VerificationResult{
+								Success: false,
+								Reason:  "x5u certificate public key does not match signature certificateChain leaf",
+							}
+						} else {
 			var trustedX509Identities []map[string]string
 			for _, identity := range req.TrustPolicy.TrustedIdentities {
 				identityPrefix, identityValue, _ := strings.Cut(identity, ":")
@@ -94,6 +158,10 @@ func Verify(ctx context.Context, req *plugin.VerifySignatureRequest) (*plugin.Ve
 				}
 			}
 
+						}
+					}
+				}
+			}
 		}
 		attr = append(attr, jws.HeaderVerificationPluginX5U)
 	} else {


### PR DESCRIPTION
## Summary

Fixes CWE-345 vulnerability where the verifier plugin could be tricked into accepting forged trusted identities by serving an attacker-controlled certificate via the x5u extended attribute without binding it to the actual signing certificate.

## Finding

**CWE-345: Insufficient Verification of Data Authenticity**

The `signature.Verify()` function computed the `SIGNATURE_VERIFIER.TRUSTED_IDENTITY` verdict from a certificate fetched from an attacker-controlled `com.venafi.notation.plugin.x5u` envelope header without:
- Validating the x5u URL scheme or host
- Binding the fetched certificate to the envelope's x5c signing chain by public key, fingerprint, or signature
- Safe type assertion on the x5u attribute

This allowed any holder of a trust-store-chained certificate to impersonate any trustedIdentities DN by hosting a fake certificate and pointing the x5u header to it.

## Remediation

Applied three mitigations in `internal/signature/verifier.go`:

1. **Safe type assertion**: Added two-value type assertion for x5u attribute with fail-closed error handling
2. **URL validation**: Require x5u URL to use HTTPS scheme and match the configured TPP host from pluginConfig
3. **Certificate binding**: Compare `RawSubjectPublicKeyInfo` of the fetched x5u certificate against the envelope's `CertificateChain[0]` to ensure they represent the same key

The fix ensures that:
- Only HTTPS URLs from the configured TPP host are accepted
- The certificate identity being validated cryptographically matches the key that signed the envelope
- Malformed x5u attributes fail closed rather than panicking

## Verification

- Signature package builds successfully: `go build ./internal/signature/...` ✓
- No test regressions (package has no tests)
- Fix addresses all three defects identified in the security analysis:
  - Type assertion panic (defect #1)
  - CWE-345 identity binding (defect #2)  
  - CWE-918 origin validation (defect #3)

Note: Pre-existing go vet warnings in `internal/revoke/revoke.go` are unrelated to this fix.