### PR TITLE
signature: make verificationPlugin attribute opt-out

### DIFF
--- a/internal/signature/jws/jws.go
+++ b/internal/signature/jws/jws.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -185,8 +186,16 @@ func SignJWSEnvelope(jwsOpts JWSOptions) ([]byte, error) {
 }
 
 func GenerateExtendedAttributes(x5u string) []signature.Attribute {
-	// Need extended protected headers for plugin signature envelope verification
 	var ext []signature.Attribute
+
+	// when set, omit the verificationPlugin requirement so signatures verify
+	// with a standard X.509 trust store * trust policy and no plugin/CodeSign at verify
+	// time - required for offline/air-gapped verification.
+	if os.Getenv("VENAFI_CSP_NO_VERIFICATION_PLUGIN") != "" {
+		return ext
+	}
+
+	// Need extended protected headers for plugin signature envelope verification
 	ext = append(ext, signature.Attribute{Key: headerVerificationPlugin, Value: version.PluginName, Critical: true})
 	ext = append(ext, signature.Attribute{Key: headerVerificationPluginMinVersion, Value: version.GetVerificationPluginMinVersion(), Critical: true})
 	// Test custom extended attribute


### PR DESCRIPTION
Signatures always embed the io.cnfc.notary.verificationPlugin signed attribute, which forces every verifier to invoke the plugin and breaks offline verification against a plain trust store and policy.

The env var added on this commit omits the attribute so singatures can verify offline.